### PR TITLE
Update Email.ps1

### DIFF
--- a/Logging/targets/Email.ps1
+++ b/Logging/targets/Email.ps1
@@ -19,7 +19,7 @@
 
         $Params['SmtpServer'] = $Configuration.SMTPServer
         $Params['From'] = $Configuration.From
-        $Params['To'] = $Configuration.To
+        $Params['To'] = $Configuration.To.Replace("'","").Split(",")
         $Params['Body'] = Replace-Token -String $Format -Source $Log
 
         if ($Configuration.Subject) {


### PR DESCRIPTION
When I try to write to several email addresses, I get the following error:

```
To has to be of type System.String for target Email
At C:\windows\system32\WindowsPowerShell\v1.0\Modules\Logging\Logging.psm1:303 char:13
+             throw ('Configuration {0} has to be of type {1} for targe ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Configuration T...or target Email:String) [], RuntimeException
    + FullyQualifiedErrorId : Configuration To has to be of type System.String for target Email
```