### PR TITLE
Implement OverrideColorMapping for Console target

### DIFF
--- a/Logging/targets/Console.ps1
+++ b/Logging/targets/Console.ps1
@@ -4,6 +4,7 @@
     Configuration = @{
         Level  = @{Required = $false; Type = [string]}
         Format = @{Required = $false; Type = [string]}
+        ColorMapping = @{Required = $false; Type = [hashtable]}
     }
     Logger = {
         param(
@@ -17,6 +18,19 @@
             'INFO' = 'Green'
             'WARNING' = 'Yellow'
             'ERROR' = 'Red'
+        }
+
+        if ($Configuration.ColorMapping) {
+            foreach ($Level in $Configuration.ColorMapping.Keys) {
+                $Color = $Configuration.ColorMapping[$Level]
+                
+                if ($Color -notin ([System.Enum]::GetNames([System.ConsoleColor]))) {
+                    $ParentHost.UI.WriteErrorLine("ERROR: Cannot use custom color '$Color': not a valid [System.ConsoleColor] value")
+                    continue
+                }
+                
+                $ColorMapping[$Level] = $Configuration.ColorMapping[$Level]
+            }
         }
 
         $mtx = New-Object System.Threading.Mutex($false, 'ConsoleMtx')

--- a/README.md
+++ b/README.md
@@ -163,8 +163,30 @@ The mutex name to acquire is ```ConsoleMtx```
 
 ```powershell
 > Add-LoggingTarget -Name Console -Configuration @{
-    Level       = <NOTSET>          # <Not required> Sets the logging level for this target
-    Format      = <NOTSET>          # <Not required> Sets the logging format for this target
+    Level        = <NOTSET>         # <Not required> Sets the logging level for this target
+    Format       = <NOTSET>         # <Not required> Sets the logging format for this target
+    ColorMapping = <NOTSET>         # <Not required> Overrides the level:color mappings with a [hashtable].
+                                    #                Only need to specify the levels you wish to override
+}
+```
+##### Colors
+Default Console Colors
+```powershell
+$ColorMapping = @{
+    'DEBUG'   = 'Blue'
+    'INFO'    = 'Green'
+    'WARNING' = 'Yellow'
+    'ERROR'   = 'Red'
+}
+```
+
+Each color will be verified against `[System.ConsoleColor]`. If it is invalid, an error will appear on the screen along with the orignal message.
+```powershell
+Add-LoggingTarget -Name Console -Configuration @{
+    ColorMapping = @{
+        DEBUG = 'Gray'
+        INFO  = 'White'
+    }
 }
 ```
 


### PR DESCRIPTION
Adds the ability to override Level:Color mapping for console logging in the `Configuration` parameter using a `[hashtable]` like 
```powershell
Add-LoggingTarget -Name Console -Configuration @{
    ColorMapping = @{
        DEBUG = 'Gray'
        INFO  = 'White'
    }
```
Parameter is not required, and only replaces the colors defined in the `ColorMapping` hashtable