### PR TITLE
Changed from -Option ReadOnly to -Option Constant.

### DIFF
--- a/Logging/Logging.psm1
+++ b/Logging/Logging.psm1
@@ -19,12 +19,12 @@ $LN = [hashtable]::Synchronized(@{
     'DEBUG' = $DEBUG
 })
 
-New-Variable -Name Dispatcher   -Value ([hashtable]::Synchronized(@{})) -Option ReadOnly
-New-Variable -Name LevelNames   -Value $LN -Option ReadOnly
-New-Variable -Name Logging      -Value ([hashtable]::Synchronized(@{})) -Option ReadOnly
-New-Variable -Name LogTargets   -Value ([hashtable]::Synchronized(@{})) -Option ReadOnly
-New-Variable -Name MessageQueue -Value ([System.Collections.ArrayList]::Synchronized([System.Collections.ArrayList] @())) -Option ReadOnly
-New-Variable -Name ScriptRoot   -Value (Split-Path $MyInvocation.MyCommand.Path) -Option ReadOnly
+New-Variable -Name Dispatcher   -Value ([hashtable]::Synchronized(@{})) -Option Constant
+New-Variable -Name LevelNames   -Value $LN -Option Constant
+New-Variable -Name Logging      -Value ([hashtable]::Synchronized(@{})) -Option Constant
+New-Variable -Name LogTargets   -Value ([hashtable]::Synchronized(@{})) -Option Constant
+New-Variable -Name MessageQueue -Value ([System.Collections.ArrayList]::Synchronized([System.Collections.ArrayList] @())) -Option Constant
+New-Variable -Name ScriptRoot   -Value (Split-Path $MyInvocation.MyCommand.Path) -Option Constant
 
 $Defaults = @{
     Level = $NOTSET
@@ -132,4 +132,3 @@ $ExecutionContext.SessionState.Module.OnRemove = {
     [System.GC]::Collect()
 }
 #endregion Handle Module Removal
-


### PR DESCRIPTION
Reasoning :
- With Constant a recreation of the variables is forbidden (accidental override, etc.)
=> Values can still be added, as only the change of the variables value is perhibited (stores address referencing collection)