### PR TITLE
Fixed bug related to the issue "Loglevel is ignored #61"

### DIFF
--- a/Logging/private/Initialize-LoggingTarget.ps1
+++ b/Logging/private/Initialize-LoggingTarget.ps1
@@ -27,5 +27,5 @@ function Initialize-LoggingTarget {
     }
 
     $ParentHost.NotifyEndApplication()
-    [System.Threading.Monitor]::Enter($LoggingRunspace.syncRoot)
+    [System.Threading.Monitor]::Exit($LoggingRunspace.syncRoot)
 }

--- a/Logging/private/Merge-DefaultConfig.ps1
+++ b/Logging/private/Merge-DefaultConfig.ps1
@@ -11,14 +11,14 @@ function Merge-DefaultConfig {
 
     foreach ($Param in $DefaultConfiguration.Keys) {
         if ($Param -in $ParamsRequired -and $Param -notin $Configuration.Keys) {
-            throw ('Configuration {0} is required for target {1}; please provide one of type {2}' -f $Param, $TargetName, $DefaultConfiguration[$Param].Type)
+            throw ('Configuration {0} is required for target {1}; please provide one of type {2}' -f $Param, $Target, $DefaultConfiguration[$Param].Type)
         }
 
         if ($Configuration.ContainsKey($Param)) {
             if ($Configuration[$Param] -is $DefaultConfiguration[$Param].Type) {
                 $result[$Param] = $Configuration[$Param]
             } else {
-                throw ('Configuration {0} has to be of type {1} for target {2}' -f $Param, $DefaultConfiguration[$item.Key].Type, $TargetName)
+                throw ('Configuration {0} has to be of type {1} for target {2}' -f $Param, $DefaultConfiguration[$Param].Type, $Target)
             }
         } else {
             $result[$Param] = $DefaultConfiguration[$Param].Default

--- a/Logging/private/Start-LoggingManager.ps1
+++ b/Logging/private/Start-LoggingManager.ps1
@@ -20,7 +20,7 @@ function Start-LoggingManager {
     }
 
     # Importing functions into runspace
-    foreach ($Function in 'Replace-Token', 'Initialize-LoggingTarget') {
+    foreach ($Function in 'Replace-Token', 'Initialize-LoggingTarget', 'Get-LevelNumber') {
         Write-Verbose "Importing function $($Function) into runspace"
         $Body = Get-Content Function:\$Function
         $f = New-Object System.Management.Automation.Runspaces.SessionStateFunctionEntry -ArgumentList $Function, $Body
@@ -50,7 +50,9 @@ function Start-LoggingManager {
                         [hashtable] $TargetConfiguration = $targetEnum.Current.Value
                         $Logger = [scriptblock] $Script:Logging.Targets[$LoggingTarget].Logger
 
-                        if ($Log.LevelNo -ge $TargetConfiguration.LevelNo) {
+                        $targetLevelNo = Get-LevelNumber -Level $TargetConfiguration.Level
+
+                        if ($Log.LevelNo -ge $targetLevelNo) {
                             Invoke-Command -ScriptBlock $Logger -ArgumentList @($Log, $TargetConfiguration)
                         }
                     }

--- a/Logging/public/Set-LoggingDefaultLevel.ps1
+++ b/Logging/public/Set-LoggingDefaultLevel.ps1
@@ -35,8 +35,8 @@ function Set-LoggingDefaultLevel {
     End {
         $Script:Logging.Level = $PSBoundParameters.Level
         $Script:Logging.LevelNo = Get-LevelNumber -Level $PSBoundParameters.Level
-        foreach ($Target in $Script:Logging.Targets.Values) {
-            $Target['Level'] = $Script:Logging.Level
+        foreach ($Target in ($Script:Logging.Targets.Values | Where-Object {$_.Defaults.Contains('Level')})) {
+            $Target.Defaults.Level.Default = $Script:Logging.Level
         }
     }
 }


### PR DESCRIPTION
1. Fixed bug related to the issue "Loglevel is ignored #61":
The bug still exists (Reproduced on PowerShell 5.1 (Windows 10 1903), PowerShell 6.2.2 (Ubuntu)) e.g:

PS /home/pavel> ipmo Logging
PS /home/pavel> Set-LoggingDefaultLevel -Level WARNING
PS /home/pavel> Add-LoggingTarget -Name Console
PS /home/pavel> Write-Log -Level INFO -Message 'Test'
PS /home/pavel> [2019-08-19 23:11:34+03] [INFO ] Test

The same result is on Windows 10 computer.

2. Fixed minor bugs in functions Initialize-LoggingTarget; Merge-DefaultConfig