### PR TITLE
Fix console hang on exit

### DIFF
--- a/Logging/Logging.psd1
+++ b/Logging/Logging.psd1
@@ -69,7 +69,7 @@ Description = 'Powershell Logging Module'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-# FunctionsToExport = @('Use-LogMessage','Add-LoggingLevel','Add-LoggingTarget','Get-LoggingMessageCount','Get-LoggingCallerScope','Get-LoggingDefaultFormat','Get-LoggingDefaultLevel','Get-LoggingTarget','Get-LoggingAvailableTarget','Set-LoggingCallerScope','Set-LoggingCustomTarget','Set-LoggingDefaultFormat','Set-LoggingDefaultLevel','Wait-Logging','Write-Log')
+FunctionsToExport = @('Use-LogMessage','Add-LoggingLevel','Add-LoggingTarget','Get-LoggingMessageCount','Get-LoggingCallerScope','Get-LoggingDefaultFormat','Get-LoggingDefaultLevel','Get-LoggingTarget','Get-LoggingAvailableTarget','Set-LoggingCallerScope','Set-LoggingCustomTarget','Set-LoggingDefaultFormat','Set-LoggingDefaultLevel','Wait-Logging','Write-Log')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()


### PR DESCRIPTION
Fixes #62 

The reason console would hang is because `$OnRemoval` cleanup wouldn't work and the log event consumer thread would stay blocked, which must be somehow preventing PowerShell from exiting.

`Register-EngineEvent` calls the scriptblock in the global scope where `$Script:LoggingEventQueue` doesn't exist. You can see this if you add `try { ... } catch { Write-Host $_ }` in the `$OnRemoval` scriptblock, you'll get a null reference exception.

Also, noticed that PowerShell module auto-load didn't work, I think it's because `FunctionsToExport` is commented.