### PR TITLE
Fix module unload

### DIFF
--- a/Logging/private/Start-LoggingManager.ps1
+++ b/Logging/private/Start-LoggingManager.ps1
@@ -88,6 +88,6 @@ function Start-LoggingManager {
     $ExecutionContext.SessionState.Module.OnRemove += $OnRemoval
 
     # This scriptblock would be called within the global scope and wouldn't have access to internal module variables and functions that we need
-    $Script:LoggingRunspace.EngineEvent = Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Action $OnRemoval
+    $Script:LoggingRunspace.EngineEventJob = Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Action $OnRemoval
     #endregion Handle Module Removal
 }

--- a/Logging/private/Stop-LoggingManager.ps1
+++ b/Logging/private/Stop-LoggingManager.ps1
@@ -8,7 +8,7 @@ function Stop-LoggingManager {
     [void] $Script:LoggingRunspace.Powershell.Dispose()
 
     $ExecutionContext.SessionState.Module.OnRemove = $null
-    Unregister-Event -SubscriptionId $Script:LoggingRunspace.EngineEvent.id
+    Get-EventSubscriber | Where-Object { $_.Action.Id -eq $Script:LoggingRunspace.EngineEventJob.Id } | Unregister-Event
 
     Remove-Variable -Scope Script -Force -Name LoggingEventQueue
     Remove-Variable -Scope Script -Force -Name LoggingRunspace

--- a/Logging/private/Stop-LoggingManager.ps1
+++ b/Logging/private/Stop-LoggingManager.ps1
@@ -8,7 +8,10 @@ function Stop-LoggingManager {
     [void] $Script:LoggingRunspace.Powershell.Dispose()
 
     $ExecutionContext.SessionState.Module.OnRemove = $null
-    Get-EventSubscriber | Where-Object { $_.Action.Id -eq $Script:LoggingRunspace.EngineEventJob.Id } | Unregister-Event
+    Get-EventSubscriber | ForEach-Object {
+        Write-Host "Current Action.Id $($_.Action.Id); Looking for id: $($Script:LoggingRunspace.EngineEventJob.Id)"
+        $_
+    } | Where-Object { $_.Action.Id -eq $Script:LoggingRunspace.EngineEventJob.Id } | Unregister-Event
 
     Remove-Variable -Scope Script -Force -Name LoggingEventQueue
     Remove-Variable -Scope Script -Force -Name LoggingRunspace

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -45,6 +45,7 @@ Properties {
 
     Import-Module $env:BHPSModuleManifest -Global
     $ExportedFunctions = Get-Command -Module $env:BHProjectName | select -ExpandProperty Name
+    Remove-Module -Name $env:BHPSModuleManifest -Force
 }
 
 FormatTaskName (('-' * 25) + ('[ {0,-28} ]') + ('-' * 25))
@@ -82,8 +83,6 @@ Task CodeAnalisys -Depends Init {
 }
 
 Task Tests -Depends CodeAnalisys {
-    Get-Module $env:BHProjectName | Remove-Module -Force
-
     $TestResults = Invoke-Pester -Path $TestsFolder -PassThru -OutputFormat NUnitXml -OutputFile $TestsFile
 
     switch ($env:BHBuildSystem) {


### PR DESCRIPTION
Apparently, `Register-EngineEvent` output cannot be used to call `Unregister-Event`. Changed the logic to find the correct event subscription by matching Action.Id