### PR TITLE
Fix startup race condition

### DIFF
--- a/Logging/Logging.psm1
+++ b/Logging/Logging.psm1
@@ -20,6 +20,3 @@ Export-ModuleMember -Function $PublicFunctions.BaseName
 Set-LoggingVariables
 
 Start-LoggingManager
-
-# Let the runspace spinup and generate all the available targets
-Start-Sleep -Milliseconds 500

--- a/Logging/private/Stop-LoggingManager.ps1
+++ b/Logging/private/Stop-LoggingManager.ps1
@@ -8,10 +8,7 @@ function Stop-LoggingManager {
     [void] $Script:LoggingRunspace.Powershell.Dispose()
 
     $ExecutionContext.SessionState.Module.OnRemove = $null
-    Get-EventSubscriber | ForEach-Object {
-        Write-Host "Current Action.Id $($_.Action.Id); Looking for id: $($Script:LoggingRunspace.EngineEventJob.Id)"
-        $_
-    } | Where-Object { $_.Action.Id -eq $Script:LoggingRunspace.EngineEventJob.Id } | Unregister-Event
+    Get-EventSubscriber | Where-Object { $_.Action.Id -eq $Script:LoggingRunspace.EngineEventJob.Id } | Unregister-Event
 
     Remove-Variable -Scope Script -Force -Name LoggingEventQueue
     Remove-Variable -Scope Script -Force -Name LoggingRunspace

--- a/Logging/private/Stop-LoggingManager.ps1
+++ b/Logging/private/Stop-LoggingManager.ps1
@@ -15,4 +15,5 @@ function Stop-LoggingManager {
 
     Remove-Variable -Scope Script -Force -Name LoggingEventQueue
     Remove-Variable -Scope Script -Force -Name LoggingRunspace
+    Remove-Variable -Scope Script -Force -Name TargetsInitSync
 }


### PR DESCRIPTION
It's more reliable to have a deterministic way of knowing when the consumer has loaded logging targets.

Fixes #73 