### PR TITLE
Fixes an issue in AzureLogAnalytics target #101

### DIFF
--- a/Logging/targets/AzureLogAnalytics.ps1
+++ b/Logging/targets/AzureLogAnalytics.ps1
@@ -80,7 +80,7 @@
         $Log.timestamputc = $Log.timestamputc | Get-Date -UFormat '+%Y-%m-%dT%H:%M:%S.000Z'
 
         # See if a Body was provided, that needs to be expanded.
-        if ($Log.ContainsKey('Body')) {
+        if ($Log.Body) {
             $Log = $Log + $Log.Body
             $Log.Remove('Body')
         }

--- a/Tests/AzureLogAnalytics.Tests.ps1
+++ b/Tests/AzureLogAnalytics.Tests.ps1
@@ -24,9 +24,18 @@ Describe -Tags Targets, TargetAzureLogAnalytics 'AzureLogAnalytics target' {
         $Module = . $TargetImplementationPath
 
         $Log = [hashtable] @{
-            level   = 'INFO'
-            essage = 'Hello, Azure!'
+            timestamp    = Get-Date -UFormat '%Y-%m-%dT%T%Z'
             timestamputc = '2020-02-24T22:35:23.000Z'
+            level        = 'INFO'
+            levelno      = 20
+            lineno       = 1
+            pathname     = 'c:\Scripts\Script.ps1'
+            filename     = 'TestScript.ps1'
+            caller       = 'TestScript.ps1'
+            message      = 'Hello, Azure!'
+            body         = $null
+            execinfo     = $null
+            pid          = $PID
         }
 
         $Configuration = @{
@@ -35,7 +44,7 @@ Describe -Tags Targets, TargetAzureLogAnalytics 'AzureLogAnalytics target' {
             LogType = 'TestLog'
         }
 
-        & $Module.Logger $Log $Configuration
+        { & $Module.Logger $Log $Configuration } | Should -Not -Throw
 
         Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 1 -Exactly
     }


### PR DESCRIPTION
This PR fixes an issue in AzureLogAnalytics target, causes `A hash table can only be added to another hash table.` error message every time a new log message is submitted without a `Body` parameter.

Additionally, this PR extends the Pester test to make sure that the target is tested against the complete Log object and not against a simplified copy (which is probably why this issue was missed initially) 