### PR TITLE
Resolve relative Path in File target

### DIFF
--- a/Logging/public/Add-LoggingTarget.ps1
+++ b/Logging/public/Add-LoggingTarget.ps1
@@ -34,8 +34,16 @@ function Add-LoggingTarget {
     End {
         $Script:Logging.EnabledTargets[$PSBoundParameters.Name] = Merge-DefaultConfig -Target $PSBoundParameters.Name -Configuration $Configuration
 
-        if ($Script:Logging.EnabledTargets[$PSBoundParameters.Name].Init -is [scriptblock]) {
-            & $Script:Logging.EnabledTargets[$PSBoundParameters.Name].Init $Configuration
+        # Special case hack - resolve target file path if it's a relative path
+        # This can't be done in the Init scriptblock of the logging target because that scriptblock gets created in the
+        # log consumer runspace and doesn't inherit the current SessionState. That means that the scriptblock doesn't know the
+        # current working directory at the time when `Add-LoggingTarget` is being called and can't accurately resolve the relative path.
+        if(($PSBoundParameters.Name -eq 'File') -and (-not [System.IO.Path]::IsPathFullyQualified($Configuration.Path))){
+            $Script:Logging.EnabledTargets[$PSBoundParameters.Name].Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Configuration.Path)
+        }
+
+        if ($Script:Logging.Targets[$PSBoundParameters.Name].Init -is [scriptblock]) {
+            & $Script:Logging.Targets[$PSBoundParameters.Name].Init $Configuration
         }
     }
 }

--- a/Logging/public/Add-LoggingTarget.ps1
+++ b/Logging/public/Add-LoggingTarget.ps1
@@ -38,7 +38,7 @@ function Add-LoggingTarget {
         # This can't be done in the Init scriptblock of the logging target because that scriptblock gets created in the
         # log consumer runspace and doesn't inherit the current SessionState. That means that the scriptblock doesn't know the
         # current working directory at the time when `Add-LoggingTarget` is being called and can't accurately resolve the relative path.
-        if(($PSBoundParameters.Name -eq 'File') -and (-not [System.IO.Path]::IsPathFullyQualified($Configuration.Path))){
+        if($PSBoundParameters.Name -eq 'File'){
             $Script:Logging.EnabledTargets[$PSBoundParameters.Name].Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Configuration.Path)
         }
 

--- a/Tests/FileTarget.Tests.ps1
+++ b/Tests/FileTarget.Tests.ps1
@@ -1,0 +1,21 @@
+﻿if (Get-Module Logging) {
+    Remove-Module Logging -Force -ErrorAction SilentlyContinue
+}
+
+$ManifestPath = '{0}\..\Logging\Logging.psd1' -f $PSScriptRoot
+
+Import-Module $ManifestPath -Force
+
+Describe -Tags Targets, TargetFile 'File target' {
+
+    It 'should resolve relative paths' {
+
+        Add-LoggingTarget -Name File -Configuration @{
+            Path  = '..\Test.log'
+        }
+
+        $a = Get-LoggingTarget
+        $a.Values.Path.Contains('..') | Should Be $false
+    }
+
+}


### PR DESCRIPTION
Not very clean, because it adds File target specific code to a module function, but couldn't come up with something better. Init scriptblocks are created in another runspace, so they will not know the current $PWD of the runspace that is calling `Add-LoggingTarget`
Fixes #91

Also, fixes Init scriptblocks weren't being called because they aren't a part of `$Script:Logging.EnabledTargets[$PSBoundParameters.Name]`, they're defined in `$Script:Logging.Targets[$PSBoundParameters.Name]`

EDIT
Had to remove the call to `[System.IO.Path]::IsPathFullyQualified()` because it's only available in Core. Resolving all paths shouldn't negatively impact already fully qualified paths