### PR TITLE
Updated Team target 

### DIFF
--- a/Logging/Logging.psd1
+++ b/Logging/Logging.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Logging.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.3.2'
+ModuleVersion = '4.4.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Logging/Logging.psm1
+++ b/Logging/Logging.psm1
@@ -3,8 +3,8 @@ $PSModule = $ExecutionContext.SessionState.Module
 $PSModuleRoot = $PSModule.ModuleBase
 
 # Dot source public/private functions
-$PublicFunctions = @(Get-ChildItem -Path "$SCriptPath\public" -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue)
-$PrivateFunctions = @(Get-ChildItem -Path "$SCriptPath\private" -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue)
+$PublicFunctions = @(Get-ChildItem -Path "$ScriptPath\public" -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue)
+$PrivateFunctions = @(Get-ChildItem -Path "$ScriptPath\private" -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue)
 
 $AllFunctions = $PublicFunctions + $PrivateFunctions
 foreach ($Function in $AllFunctions) {

--- a/Logging/targets/Teams.ps1
+++ b/Logging/targets/Teams.ps1
@@ -29,9 +29,29 @@
         $sections = @()
 
         if ($Log.Body) {
-            $body = [ordered] @{}
-            $body.activitySubtitle = 'Body'
-            $body.text = $Log.Body | ConvertTo-Json -Depth 3 -Compress
+            $body = [ordered]@{};
+
+            if ($Log.Body.Activity) {
+                $body.activityTitle     = @('Body', $Log.Body.Activity.title)[[bool]$Log.Body.Activity.title]
+                $body.activitySubTitle  = $Log.Body.Activity.subtitle
+                $body.text              = $Log.Body.Activity.text
+            } elseif ($Log.Body.Facts) {
+                $body.title             = 'Facts'
+                if ($Log.Body.Facts -is [array]) {
+                    $body.facts         = $Log.Body.Facts
+                } elseif ($Log.Body.Facts -is [hashtable]) {
+                    $body.facts         = $Log.Body.Facts.Keys |%{ @{ name = $_; value = $Log.Body.Facts[$_]; } }
+                } else {
+                    $body.facts         = @{ name='fact'; value = $($Log.Body.Facts | ConvertTo-Json -Depth 3 -Compress); }
+                }
+            } elseif ($Log.Body -is [string]) {
+                $body.activityTitle     = 'Body'
+                $body.text              = $Log.Body
+            } else {
+                $body.activityTitle     = 'Body'
+                $body.text              = $Log.Body | ConvertTo-Json -Depth 3 -Compress
+            }
+
             $sections += $body
         }
 

--- a/Logging/targets/Teams.ps1
+++ b/Logging/targets/Teams.ps1
@@ -40,9 +40,17 @@
                 if ($Log.Body.Facts -is [array]) {
                     $body.facts         = $Log.Body.Facts
                 } elseif ($Log.Body.Facts -is [hashtable]) {
-                    $body.facts         = $Log.Body.Facts.Keys |%{ @{ name = $_; value = $Log.Body.Facts[$_]; } }
+                    $body.facts         = $Log.Body.Facts.Keys | %{
+                                                @{
+                                                    name = $_
+                                                    value = $Log.Body.Facts[$_]
+                                                }
+                                            }
                 } else {
-                    $body.facts         = @{ name='fact'; value = $($Log.Body.Facts | ConvertTo-Json -Depth 3 -Compress); }
+                    $body.facts         = @{
+                            name='fact'
+                            value = $($Log.Body.Facts | ConvertTo-Json -Depth 3 -Compress)
+                        }
                 }
             } elseif ($Log.Body -is [string]) {
                 $body.activityTitle     = 'Body'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 4.4.0 (2020-06-17)
+
+- [FIX] NotifyBeginApplication/NotifyEndApplication calls not needed (#99)
+- [FIX] Fix startup race condition (#100) (@Tadas)
+- [FIX] Fixed an issue in AzureLogAnalytics target (#102) (@Glober777)
+- [FIX] Resolve relative Path in File target (#103) (@Tadas)
+- [FIX] Target name is case insensitive (#106) (@Tadas)
+
 ## 4.3.2 (2020-05-28)
 
 
@@ -160,6 +168,7 @@ It should improve logging performance to a new level thanks to the amazing work 
 - Moved to psake build tool
 - Moved to platyps doc generation tool
 - Major folder structure change
+
 
 
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,5 +1,0 @@
-- [FIX] NotifyBeginApplication/NotifyEndApplication calls not needed (#99)
-- [FIX] Fix startup race condition (#100) (@Tadas)
-- [FIX] Fixed an issue in AzureLogAnalytics target (#102) (@Glober777)
-- [FIX] Resolve relative Path in File target (#103) (@Tadas)
-- [FIX] Target name is case insensitive (#106) (@Tadas)


### PR DESCRIPTION
Updated ***Teams*** target to expand the body options. Includes the ability to send a `Markdown` string, `Activity`, collection of `Facts` (in either an array or a hashtable) or keep the original option for an `object/hashtable`. The *Activity* and *Facts* objects are designed to match the Microsoft schema to simplify things.

Below are commands to test the different options:

```PowerShell
# Testing with MarkDown based string content
Write-Log -Level ERROR  -Message 'Test message' -Body @"
#### Header 
*bold* 
**italics** 
_italics2_ 
``ticked``
"@;
# Testing with Activity details in a hashtable
Write-Log -Level ERROR  -Message 'Test message' -Body @{Activity=@{title='actTitle';subtitle='actSub';text='*markdown* _data_ [PowerShell](https://docs.microsoft.com/en-us/powershell/)'}};
# Testing with Facts in a hashtable - Creates facts section
Write-Log -Level ERROR  -Message 'Test message' -Body @{Facts=@{TestFact1='FactValue1';TestFact2='FactValue2'}};
# Testing with Facts in an array - basic facts addition
Write-Log -Level ERROR  -Message 'Test message' -Body @{Facts=@(@{name='TestFact1';value='FactValue1'},@{name='TestFact2';value='FactValue2'})};
# Testing with hashtable of random properties
Write-Log -Level ERROR  -Message 'Test message' -Body @{source= 'Test Source Value'; testkey1="Test Value 1"};
```