### PR TITLE
Added initialization to file target

### DIFF
--- a/Logging/targets/File.ps1
+++ b/Logging/targets/File.ps1
@@ -9,7 +9,20 @@
         Level          = @{Required = $false; Type = [string]; Default = $Logging.Level }
         Format         = @{Required = $false; Type = [string]; Default = $Logging.Format }
     }
+    Init          = {
+        param(
+            [hashtable] $Configuration
+        )
 
+        [String] $directoryPath = [System.IO.Path]::GetDirectoryName($Configuration.Path)
+
+        # We (try to) create the directory if it is not yet given
+        if (-not [System.IO.Directory]::Exists($directoryPath)){
+            # "Creates all directories and subdirectories in the specified path unless they already exist."
+            # https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.createdirectory?view=net-5.0#System_IO_Directory_CreateDirectory_System_String_
+            [System.IO.Directory]::CreateDirectory($directoryPath) | Out-Null
+        }
+    }
     Logger        = {
         param(
             [hashtable] $Log,


### PR DESCRIPTION
# Description

Added a small change to allow for the initialization of the file target. This includes that the directory is (tried to be) created, when it is not yet given. 

Fixes # Prevents the logging from failing, if the directory is not yet present on the system.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This change was tested on local clients by trying to start logging to a file where
- the directory is present
- the directory is not yet present