### PR TITLE
SEQ: fix event type and implement properties

### DIFF
--- a/Logging/targets/Seq.ps1
+++ b/Logging/targets/Seq.ps1
@@ -26,6 +26,11 @@
 
         $Body += $Log
 
+        if($null -ne $Configuration.Properties)
+        {
+            $Body += $Configuration.Properties
+        }
+
         if ($Configuration.ApiKey) {
             $Url = '{0}/api/events/raw?clef&apiKey={1}' -f $Configuration.Url, $Configuration.ApiKey
         }

--- a/Logging/targets/Seq.ps1
+++ b/Logging/targets/Seq.ps1
@@ -15,7 +15,7 @@
 
         $Body = @{
             "@t"       = $Log.TimestampUtc
-            "@l"       = $Configuration.Level
+            "@l"       = $Log.Level.substring(0,1).toupper()+$Log.Level.substring(1).tolower()
             "@m"       = $Log.Message
             "@mt"      = $Log.RawMessage
         }


### PR DESCRIPTION
- fixed event type. Previous: 
![image](https://user-images.githubusercontent.com/26710574/132511759-73526fbb-97d6-49cc-8702-3cc4d49a3645.png)
Now: 
![image](https://user-images.githubusercontent.com/26710574/132511928-7f1871a4-49f0-46db-a11d-fd3514ca9ac1.png)

- Write default "properties" in logging target to event log too
![image](https://user-images.githubusercontent.com/26710574/132512230-c41cc682-7937-442a-965e-53edc9a79c92.png)
```powershell
Add-LoggingTarget -Name Seq -Configuration @{
    Url         = "https://xxx.x.net"          # <Required> Url to Seq instance
    ApiKey      = "xxx"          # <Not required> Api Key to authenticate to Seq
    Properties  = @{
        "TestProperty" = "test_value"
        "TestProperty2" = "test_value2"
    }          # <Required> Hashtable of user defined properties to be added to each Seq message
}
```

PR made against master, because dev is quite a few commits behind of master. Let me know if you want the PR in a different way. 