### PR TITLE
Added target for GELF and SQLite endpoints

### DIFF
--- a/Logging/targets/Gelf.ps1
+++ b/Logging/targets/Gelf.ps1
@@ -1,0 +1,99 @@
+﻿<#
+
+This target can be used to send gelf messages to server, for instance a Graylog server.
+
+Parameters:
+    - Server: Defines the fqdn of the gelf endpoint
+    - Port: Defines the port used for the gelf endpoint
+    - Level: Defines the level of messages that will be sent to target.
+    - Hostname: Defines the attribute hostname on the gelf message, defaults to (hostname)
+    - Format: Defines the format of the shortmessage attribute on the gelf message
+    - Protocol: Defines if the gelf message should be submitted with TCP or UDP.
+    - AdditionalField: Defines a hashtable of additional fields to submit.
+
+Prereqs:
+    This target depends on the powershell module PSGELF, make sure that module is installed and available.
+
+#>
+
+@{
+    Name          = 'Gelf'
+    Configuration = @{
+        Server          = @{Required = $true; Type = [string]; Default = $null }
+        Port            = @{Required = $true; Type = [int]; Default = $null }
+        Level           = @{Required = $false; Type = [string]; Default = $Logging.Level }
+        HostName        = @{Required = $false; Type = [string]; Default = (hostname) }
+        Format          = @{Required = $false; Type = [string]; Default = $Logging.Format }
+        Protocol        = @{Required = $false; Type = [string]; Default = 'TCP' }
+        AdditionalField = @{Required = $false; Type = [hashtable]; Default = $null }
+    }
+    Init          = {
+        param(
+            [hashtable] $Configuration
+        )
+
+        try
+        {
+            Import-Module PSGELF -ErrorAction Stop
+        }
+        catch
+        {
+            Write-Warning 'Unable to load module PSGELF, make sure that the module is installed and available in the context of the powershell session running the script. No logging to the gelf server will be performed.'
+        }
+
+    }
+    Logger        = {
+        param(
+            [hashtable] $Log,
+            [hashtable] $Configuration
+        )
+
+        $SyslogLevel = switch ($Log.Level)
+        {
+            'NOTSET'
+            {
+                6  # INFORMATION
+            }
+            'ERROR'
+            {
+                3  # ERROR
+            }
+            'WARNING'
+            {
+                4  # WARNING
+            }
+            'INFO'
+            {
+                6  # INFORMATION
+            }
+            'DEBUG'
+            {
+                7  # DEBUG
+            }
+        }
+
+        $Params = @{
+            GelfServer   = $Configuration.Server
+            Port         = $Configuration.Port
+            ShortMessage = (Format-Pattern -Pattern $Configuration.Format -Source $Log)
+            Level        = $SysLogLevel
+        }
+
+        if ($Configuration.AdditionalField)
+        {
+            $Params.AdditionalField = $Configuration.AdditionalField
+        }
+
+        switch ($Configuration.Protocol)
+        {
+            'TCP'
+            {
+                Send-PSGelfTCP @Params
+            }
+            'UDP'
+            {
+                Send-PSGelfUDP @Params
+            }
+        }
+    }
+}

--- a/Logging/targets/SQLite.ps1
+++ b/Logging/targets/SQLite.ps1
@@ -1,0 +1,93 @@
+﻿<#
+
+This target can be used to insert rows into a SQLite table
+
+Parameters:
+    - Database: Defines the path to the SQLite database
+    - TableName: Defines the name of the table to insert rows to
+    - ColumnMapping: Defines what log values should be written to witch columns in the table. See the ColumnMapping section below for more information.
+    - Level: Defines the level of messages that will be sent to target.
+    - MessageFormat: Defines the format of the message. A separate message format is used because it is unlikely that the message for the message column
+        should used the same format as specified in the default format of the module. And that format is overriding the default format specified in
+        the target definition file.
+    - PrintException: Defines that (if provided) the exception object is to be appended to the end of the message.
+
+Prereqs:
+    This target depends of the powershell module PSSQLite, make sure that module is installed and available. It is also mandatory to provision the sql
+    database and its logging table before messages can be inserted. The logging tool will not provision a new database if none can be found.
+
+Columnmapping:
+
+    Valid values for ColumnMapping is the following: pathname, pid, body, timestamp, rawmessage, lineno, filename, caller, level, timestamputc, execinfo, message, levelno.
+
+    The format of the hashtable is;
+
+    @{
+        <SQL column name> = <Value>
+        <SQL column name> = <Value>
+        <SQL column name> = <Value>
+    }
+
+    ie:
+
+    @{
+        Time = 'Timestamp'
+        Severity = 'Level'
+        Source = 'Caller'
+        Text = 'Message'
+    }
+
+    Only columns that is specified in columnmapping will be filled during insert in the database.
+
+#>
+
+@{
+    Name          = 'SQLite'
+    Configuration = @{
+        Database       = @{Required = $true; Type = [string]; Default = $null }
+        TableName      = @{Required = $true; Type = [string]; Default = $null }
+        ColumnMapping  = @{Required = $false; Type = [hashtable]; Default = @{Timestamp = 'Timestamp'; Level = 'Level'; Source = 'Caller'; Message = 'Message' } }
+        Level          = @{Required = $false; Type = [string]; Default = $Logging.Level }
+        MessageFormat  = @{Required = $false; Type = [string]; Default = '[%{lineno}] %{message}' }
+        PrintException = @{Required = $false; Type = [bool]; Default = $false }
+    }
+    Init          = {
+        param(
+            [hashtable] $Configuration
+        )
+
+        try
+        {
+            Import-Module PSSQLite -ErrorAction Stop
+        }
+        catch
+        {
+            Write-Warning 'Unable to load module PSSQLite, make sure that the module is installed and available in the context of the powershell session running the script. No logging to the SQLite database will be performed.'
+        }
+
+    }
+    Logger        = {
+        param(
+            [hashtable] $Log,
+            [hashtable] $Configuration
+        )
+
+        $Message = (Format-Pattern -Pattern $Configuration.MessageFormat -Source $Log)
+        if (![String]::IsNullOrWhiteSpace($Log.ExecInfo) -and $Configuration.PrintException)
+        {
+            $Message += "`n{0}" -f $Log.ExecInfo.Exception.Message
+            $Message += "`n{0}" -f (($Log.ExecInfo.ScriptStackTrace -split "`r`n" | ForEach-Object { "`t{0}" -f $_ }) -join "`n")
+        }
+
+        $ColumnString = $Configuration.ColumnMapping.Keys -join ','
+        $ValueString = ($Configuration.ColumnMapping.Keys -as [string[]]).Foreach({ '@' + $_ }) -join ','
+        $ColumnHash = @{}
+        foreach ($Key in $Configuration.ColumnMapping.Keys)
+        {
+            $ColumnHash.Add($Key, $Log.$($Configuration.ColumnMapping[$Key]))
+        }
+
+        $query = "INSERT INTO $($Configuration.TableName) ($ColumnString) VALUES ($ValueString)"
+        Invoke-SqliteQuery -DataSource $Configuration.Database -Query $query -SqlParameters $ColumnHash
+    }
+}


### PR DESCRIPTION
I wrote two custom targets

One for an GELF endpoint that can be used for sending logs to for instance Graylog. And one for logging to a SQLite database.

I tought I just share if you would like to include them as built-in targets.